### PR TITLE
workflow: update artifact naming in build workflow

### DIFF
--- a/.github/workflows/build_bmp_default.yml
+++ b/.github/workflows/build_bmp_default.yml
@@ -9,7 +9,6 @@ on:
   workflow_dispatch:
 
 env:
-  ARTIFACT_NAME: Firmware
   TAG_NAME: latest
 
 jobs:
@@ -18,6 +17,9 @@ jobs:
     container: qmkfm/qmk_firmware
 
     steps:
+      - name: Set short SHA
+        run: echo "SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -27,7 +29,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: Firmware_${{ env.SHORT_SHA }}
           path: ./*.uf2
 
   publish:
@@ -37,11 +39,14 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Set short SHA
+        run: echo "SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
+
       - name: Download binaries
         if: always() && !cancelled()
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: Firmware_${{ env.SHORT_SHA }}
 
       - name: Delete release
         run: gh release delete ${{ env.TAG_NAME }} --cleanup-tag || true


### PR DESCRIPTION
- Remove static `ARTIFACT_NAME` from workflow environment variables
- Add a step to set `SHORT_SHA` for each job
- Update artifact upload and download to use `Firmware_${{ env.SHORT_SHA }}`
- Improve uniqueness and traceability by using short commit SHA in names
